### PR TITLE
Adding useful scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This will ensure that a future developer (someone else or future-you!) can recre
 To upgrade the BinderHub Helm Chart:
 ```
 chmod 700 upgrade.sh
-./upgrade.sh hub23 <commit-hash>
+./upgrade.sh <commit-hash>
 ```
 where `<commit-hash>` can be found [here](https://jupyterhub.github.io/helm-chart/#development-releases-binderhub).
 
@@ -64,16 +64,16 @@ kubectl scale deployment hub --replicas=1 --namespace hub23
 
 ## Useful commands
 
-To print the IP address of the Binder page:
+To print the pods and IP addresses of the Binder page and JupyterHub:
 ```
-kubectl --namespace=hub23 get svc binder
+chmod 700 info.sh
+./info.sh
 ```
 
 To access the JupyterHub logs:
 ```
-# Print the running pods, find the one that begins with "hub-"
-kubectl get pods --namespace hub23
-kubectl logs hub-<random-string> --namespace hub23
+chmod 700 logs.sh
+./logs.sh
 ```
 
 To find out more info about a Pod:

--- a/info.sh
+++ b/info.sh
@@ -6,5 +6,5 @@ kubectl get pods -n ${1}
 echo
 
 # Get IP addresses of both the JupyterHub and BinderHub
-echo "Jupyterhub IP: " `kubectl --namespace=${1} get svc proxy-public | awk '{ print $4}' | tail -n 1`
-echo "Binderhub IP: " `kubectl --namespace=${1} get svc binder | awk '{ print $4}' | tail -n 1`
+echo "JupyterHub IP: " `kubectl --namespace=${1} get svc proxy-public | awk '{ print $4}' | tail -n 1`
+echo "Binder IP: " `kubectl --namespace=${1} get svc binder | awk '{ print $4}' | tail -n 1`

--- a/info.sh
+++ b/info.sh
@@ -2,9 +2,9 @@
 
 # Print pods
 echo "--> Printing pods"
-kubectl get pods -n ${1}
+kubectl get pods -n hub23
 echo
 
 # Get IP addresses of both the JupyterHub and BinderHub
-echo "JupyterHub IP: " `kubectl --namespace=${1} get svc proxy-public | awk '{ print $4}' | tail -n 1`
-echo "Binder IP: " `kubectl --namespace=${1} get svc binder | awk '{ print $4}' | tail -n 1`
+echo "JupyterHub IP: " `kubectl --namespace=hub23 get svc proxy-public | awk '{ print $4}' | tail -n 1`
+echo "Binder IP: " `kubectl --namespace=hub23 get svc binder | awk '{ print $4}' | tail -n 1`

--- a/info.sh
+++ b/info.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Print pods
+echo "--> Printing pods"
+kubectl get pods -n ${1}
+echo
+
+# Get IP addresses of both the JupyterHub and BinderHub
+echo "Jupyterhub IP: " `kubectl --namespace=${1} get svc proxy-public | awk '{ print $4}' | tail -n 1`
+echo "Binderhub IP: " `kubectl --namespace=${1} get svc binder | awk '{ print $4}' | tail -n 1`

--- a/logs.sh
+++ b/logs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo "--> Fetching JupyterHub logs"
+
+# Get pod name of the JupyterHub
+HUB_POD=`kubectl get pods -n hub23 -o=jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep "^hub-"`
+
+# Print the JupyterHub logs to the terminal
+kubectl logs ${HUB_POD} -n hub23

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 helm repo update
-helm upgrade $1 jupyterhub/binderhub --version=$2 -f .secret/secret.yaml -f .secret/config.yaml
+helm upgrade hub23 jupyterhub/binderhub --version=$1 -f .secret/secret.yaml -f .secret/config.yaml
 echo
-kubectl get pods -n $1
-echo "Binder IP: " `kubectl get svc binder -n $1 | awk '{ print $4}' | tail -n 1`
+kubectl get pods -n hub23
+echo
+echo "Binder IP: " `kubectl get svc binder -n hub23 | awk '{ print $4}' | tail -n 1`


### PR DESCRIPTION
This PR:
* Edits `upgrade.sh` to hard-code hub23 as the BinderHub name
* Adds `info.sh` which quickly prints the pods on the cluster and the IP addresses of the Binder page and JupyterHub
* Adds `logs.sh` which prints the logs from the JupyterHub for debugging