### PR TITLE
Install specific version of helm

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       - task: HelmInstaller@1
         displayName: 'Install Helm'
         inputs:
-          helmVersionToInstall: 'latest'
+          helmVersionToInstall: '2.16.0'
 
       - task: HelmDeploy@0
         displayName: 'Initialise Helm'


### PR DESCRIPTION
With helm version 3.0.0, --tiller-namespace flag is deprecated. Pin to 2.16.0 for now.