### PR TITLE
Updating auth config

### DIFF
--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -19,25 +19,17 @@ binderhub:
       timeout: 600
       maxAge: 21600  # maxAge is 6 hours: 6 * 3600 = 21600
 
+    custom:
+      binderauth_enabled: true
+
     hub:
       allowNamedServers: true
+      redirectToServer: false
 
       services:
         binder:
           oauth_redirect_uri: "https://binder.hub23.turing.ac.uk/oauth_callback"
           oauth_client_id: "binder-oauth-client-test"
-      extraConfig:
-        hub_extra: |
-          c.JupyterHub.redirect_to_server = False
-        binder: |
-          from kubespawner import KubeSpawner
-          class BinderSpawner(KubeSpawner):
-            def start(self):
-              if 'image' in self.user_options:
-                # binder service sets the image spec via user options
-                self.image = self.user_options['image']
-              return super().start()
-          c.JupyterHub.spawner_class = BinderSpawner
 
     singleuser:
       cmd: jupyterhub-singleuser


### PR DESCRIPTION
Use new, more concise auth configuration for BinderSpawner

See discussion [here](https://discourse.jupyter.org/t/a-persistent-binderhub-deployment/2865)