### PR TITLE
Use Let's Encrypt Staging

### DIFF
--- a/deploy/prod.yaml
+++ b/deploy/prod.yaml
@@ -66,7 +66,3 @@ binderhub:
           - "binderhub-test-org"
       scopes:
         - "read:user"
-
-cert-manager:
-  ingressShim:
-    defaultIssuerName: "prod"


### PR DESCRIPTION
Reinstalling Hub23. Use Let's Encrypt Staging for the HTTPS certificates.