### PR TITLE
Don't run subscription status check in PRs

### DIFF
--- a/.az-pipelines/subscription-test.yml
+++ b/.az-pipelines/subscription-test.yml
@@ -6,6 +6,8 @@ schedules:
     - master
   always: true
 
+pr: none
+
 pool:
   vmImage: 'ubuntu-latest'
 


### PR DESCRIPTION
Update the Check Subscription Status Azure Pipeline so it not longer runs in Pull Requests