### PR TITLE
Update Azure Pipelines to use new ingress-nginx chart

### DIFF
--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -71,7 +71,7 @@ jobs:
       targetType: 'inline'
       script: |
         helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
-        helm repo add nginx-ingress https://kubernetes-charts.storage.googleapis.com
+        helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo add jetstack https://charts.jetstack.io
         helm repo update
 

--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -70,6 +70,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        helm repo add stable https://kubernetes-charts.storage.googleapis.com
         helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo add jetstack https://charts.jetstack.io

--- a/.az-pipelines/lint-pipeline.yml
+++ b/.az-pipelines/lint-pipeline.yml
@@ -16,9 +16,9 @@ jobs:
       helmVersionToInstall: '3.3.4'
 
   - task: UsePythonVersion@0
-    displayName: 'Stage 1 Step 2: Install Python 3.7'
+    displayName: 'Stage 1 Step 2: Install Python 3.8'
     inputs:
-      versionSpec: '3.7'
+      versionSpec: '3.8'
       addToPath: true
 
   - script: python -m pip install --upgrade pip setuptools wheel

--- a/.az-pipelines/lint-pipeline.yml
+++ b/.az-pipelines/lint-pipeline.yml
@@ -42,7 +42,7 @@ jobs:
       targetType: 'inline'
       script: |
         helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
-        helm repo add nginx-ingress https://kubernetes-charts.storage.googleapis.com
+        helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo update
 
   - task: Bash@3

--- a/.az-pipelines/lint-pipeline.yml
+++ b/.az-pipelines/lint-pipeline.yml
@@ -41,6 +41,7 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
+        helm repo add stable https://kubernetes-charts.storage.googleapis.com
         helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
         helm repo update


### PR DESCRIPTION
The nginx-ingress helm chart has been deprecated and replaced with an ingress-nginx chart. This PR makes sure the correct chart is pulled in our CI/CD pipelines managed by Azure.