### PR TITLE
⬆️ Use ingress-nginx chart in hub23-chart dependencies

### DIFF
--- a/hub23-chart/requirements.yaml
+++ b/hub23-chart/requirements.yaml
@@ -2,6 +2,6 @@ dependencies:
 - name: binderhub
   repository: https://jupyterhub.github.io/helm-chart
   version: 0.2.0-n361.h6f57706
-- name: nginx-ingress
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 1.41.3
+- name: ingress-nginx
+  repository: https://kubernetes.github.io/ingress-nginx
+  version: 3.11.0


### PR DESCRIPTION
The nginx-ingress helm chart has been deprecated. This PR updates the hub23-chart's dependencies to require the new ingress-nginx chart.