### PR TITLE
Reconfigure cert-manager

### DIFF
--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -12,7 +12,7 @@ variables:
   helm_version: '3.3.4'
   kubernetes_cluster_name: 'hub23cluster'
   kubernetes_namespace: 'hub23'
-  kubernetes_version: '1.16.15'
+  kubernetes_version: '1.18.1'
   resource_group_name: 'Hub23'
   service_connection: 'hub23-deploy-scn'
 

--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -74,14 +74,14 @@ jobs:
         helm repo update
 
   - task: Bash@3
-    displayName: 'Stage 2 Step 7: Update local helm chart'
+    displayName: 'Stage 2 Step 5: Update local helm chart'
     inputs:
       targetType: 'inline'
       script: |
         cd $(HELM_CHART_NAME) && helm dep up && cd ..
 
   - task: HelmDeploy@0
-    displayName: 'Stage 2 Step 8: Perform helm upgrade'
+    displayName: 'Stage 2 Step 6: Perform helm upgrade'
     inputs:
       connectionType: 'Azure Resource Manager'
       azureSubscription: '$(SERVICE_CONNECTION)'

--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -7,7 +7,6 @@ pool:
   vmImage: 'ubuntu-latest'
 
 variables:
-  certmanager_version: 'v1.0.3'
   helm_chart_name: 'hub23-chart'
   helm_release_name: 'hub23'
   helm_version: '3.3.4'
@@ -70,34 +69,9 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        helm repo add stable https://kubernetes-charts.storage.googleapis.com
         helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
         helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-        helm repo add jetstack https://charts.jetstack.io
         helm repo update
-
-  - task: Bash@3
-    displayName: 'Stage 2 Step 5: Install cert-manager $(CERTMANAGER_VERSION) CRDs'
-    inputs:
-      targetType: 'inline'
-      script: |
-        kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/$(CERTMANAGER_VERSION)/cert-manager.crds.yaml
-
-  - task: HelmDeploy@0
-    displayName: 'Stage 2 Step 6: Install cert-manager $(CERTMANAGER_VERSION'
-    inputs:
-      connectionType: 'Azure Resource Manager'
-      azureSubscription: '$(SERVICE_CONNECTION)'
-      azureResourceGroup: '$(RESOURCE_GROUP_NAME)'
-      kubernetesCluster: '$(KUBERNETES_CLUSTER_NAME)'
-      namespace: 'cert-manager'
-      command: 'upgrade'
-      chartType: 'Name'
-      chartName: 'jetstack/cert-manager'
-      chartVersion: '$(CERTMANAGER_VERSION)'
-      releaseName: 'cert-manager'
-      valueFile: 'deploy/cert-manager.yaml'
-      arguments: '--create-namespace --timeout 10m0s --cleanup-on-fail'
 
   - task: Bash@3
     displayName: 'Stage 2 Step 7: Update local helm chart'

--- a/deploy/cert-manager.yaml
+++ b/deploy/cert-manager.yaml
@@ -1,4 +1,0 @@
-ingressShim:
-  # The default ClusterIssuer is in hub23-chart/templates/cluster-issuer.yaml
-  defaultIssuerName: letsencrypt-prod
-  defaultIssuerKind: ClusterIssuer

--- a/deploy/letsencrypt-prod.yaml
+++ b/deploy/letsencrypt-prod.yaml
@@ -1,0 +1,9 @@
+binderhub:
+  ingress:
+    annotations:
+      cert-manager.io/issuer: "hub23-letsencrypt-prod"
+
+  jupyterhub:
+    ingress:
+      annotations:
+        cert-manager.io/issuer: "hub23-letsencrypt-prod"

--- a/deploy/letsencrypt-staging.yaml
+++ b/deploy/letsencrypt-staging.yaml
@@ -1,0 +1,9 @@
+binderhub:
+  ingress:
+    annotations:
+      cert-manager.io/issuer: "hub23-letsencrypt-staging"
+
+  jupyterhub:
+    ingress:
+      annotations:
+        cert-manager.io/issuer: "hub23-letsencrypt-staging"

--- a/deploy/test-values.yaml
+++ b/deploy/test-values.yaml
@@ -1,6 +1,10 @@
 # This file contains fake secrets in order to pass the lint and validation test
 
 binderhub:
+  ingress:
+    annotations:
+      cert-manager.io/issuer: "hub23-letsencrypt-staging"
+
   config:
     GitHubRepoProvider:
       access_token: "9ab8266889889e2bc6d6e083c6fcd793c039a5aab3fe9cdfa0804a808da341c6"
@@ -10,6 +14,10 @@ binderhub:
     password: "b0edab4cfd3785eebb52439ba2f89e7666506f0076506f4c9d902da7356d5eee"
 
   jupyterhub:
+    ingress:
+      annotations:
+        cert-manager.io/issuer: "hub23-letsencrypt-staging"
+
     hub:
       services:
         binder:

--- a/docs/cert-manager/create-files.md
+++ b/docs/cert-manager/create-files.md
@@ -9,7 +9,7 @@ The resulting file structure will look as follows:
 hub23-chart/
 |-files/
 |-templates/
-| |-clusterissuer.yaml
+| |-issuer.yaml
 | |-user-configmap.yaml
 |
 |-Chart.yaml
@@ -19,30 +19,22 @@ hub23-chart/
 
 We will have already created `Chart.yaml`, `requirements.yaml` and `values.yaml` in {ref}`content:binderhub:local-chart`.
 
-## Create `templates/cluster-issuer.yaml`
+## Create `templates/issuer.yaml`
 
 ```yaml
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
-  name: letsencrypt-prod
+  name: hub23-letsencrypt-prod
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
     email: hub23registry@turing.ac.uk
     privateKeySecretRef:
-      name: letsencrypt-prod
+      name: hub23-letsencrypt-prod
     solvers:
     - http01:
         ingress:
           class: nginx
-```
-
-## Create `deploy/cert-manager.yaml`
-
-```yaml
-ingressShim:
-  defaultIssuerName: letsencrypt-prod
-  defaultIssuerKind: ClusterIssuer
 ```

--- a/docs/cert-manager/create-files.md
+++ b/docs/cert-manager/create-files.md
@@ -6,15 +6,18 @@ Some extra files are required which we will outline below.
 The resulting file structure will look as follows:
 
 ```bash
-hub23-chart/
-|-files/
-|-templates/
-| |-issuer.yaml
-| |-user-configmap.yaml
+|-deploy/
+| |-letsencrypt-staging.yaml
+| |-letsencrypt-prod.yaml
 |
-|-Chart.yaml
-|-requirements.yaml
-|-values.yaml
+|-hub23-chart/
+| |-files/
+| |-templates/
+| | |-issuer.yaml
+| | |-user-configmap.yaml
+| |-Chart.yaml
+| |-requirements.yaml
+| |-values.yaml
 ```
 
 We will have already created `Chart.yaml`, `requirements.yaml` and `values.yaml` in {ref}`content:binderhub:local-chart`.
@@ -22,6 +25,21 @@ We will have already created `Chart.yaml`, `requirements.yaml` and `values.yaml`
 ## Create `templates/issuer.yaml`
 
 ```yaml
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: hub23-letsencrypt-staging
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    email: hub23registry@turing.ac.uk
+    privateKeySecretRef:
+      name: hub23-letsencrypt-staging
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -37,4 +55,34 @@ spec:
     - http01:
         ingress:
           class: nginx
+```
+
+## Create `deploy/letsencrypt-staging.yaml` and `deploy/letsencrypt-prod.yaml`
+
+### `deploy/letsencrypt-staging.yaml`
+
+```yaml
+binderhub:
+  ingress:
+    annotations:
+      cert-manager.io/issuer: "hub23-letsencrypt-staging"
+
+  jupyterhub:
+    ingress:
+      annotations:
+        cert-manager.io/issuer: "hub23-letsencrypt-staging"
+```
+
+### `deploy/letsencrypt-prod.yaml`
+
+```yaml
+binderhub:
+  ingress:
+    annotations:
+      cert-manager.io/issuer: "hub23-letsencrypt-prod"
+
+  jupyterhub:
+    ingress:
+      annotations:
+        cert-manager.io/issuer: "hub23-letsencrypt-prod"
 ```

--- a/docs/cert-manager/deployment.md
+++ b/docs/cert-manager/deployment.md
@@ -1,31 +1,33 @@
 (content:cert-manager:deploy)=
 # Deploying `cert-manager`
 
+## Deploying `cert-manager` into a namespace
+
 ```{warning}
 Since Hub23 shares infrastructure with the turing.mybinder.org, this step should **not** be executed.
 Instead the `cert-manager` deployment should be managed from the [mybinder.org-deploy repo](https://github.com/jupyterhub/mybinder.org-deploy)
 ```
 
-## Create a namespace for `cert-manager`
+### Create a namespace for `cert-manager`
 
 ```bash
 kubectl create namespace cert-manager
 ```
 
-## Add the `cert-manager` chart repo to Helm
+### Add the `cert-manager` chart repo to Helm
 
 ```bash
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
 ```
 
-## Install the Custom Resource Definitions
+### Install the Custom Resource Definitions
 
 ```bash
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v{INSERT_VERSION_NUMBER_HERE}/cert-manager.crds.yaml
 ```
 
-## Install using Helm
+### Install using Helm
 
 ```bash
 helm install cert-manager jetstack/cert-manager \
@@ -35,3 +37,8 @@ helm install cert-manager jetstack/cert-manager \
     --timeout 5m0s \
     --wait
 ```
+
+## Performing a `helm upgrade` with the `cert-manager` configs
+
+When running `helm upgrade`, append either `-f deploy/letsencrypt-staging.yaml` or `-f deploy/letsencrypt-prod.yaml` to the command to enable the annotations in the cluster.
+Using the `staging` config will allow you to test that `cert-manager` is installed and working correctly, whereas the `prod` config will actually request certificates for your domain.

--- a/docs/cert-manager/deployment.md
+++ b/docs/cert-manager/deployment.md
@@ -1,6 +1,11 @@
 (content:cert-manager:deploy)=
 # Deploying `cert-manager`
 
+```{warning}
+Since Hub23 shares infrastructure with the turing.mybinder.org, this step should **not** be executed.
+Instead the `cert-manager` deployment should be managed from the [mybinder.org-deploy repo](https://github.com/jupyterhub/mybinder.org-deploy)
+```
+
 ## Create a namespace for `cert-manager`
 
 ```bash
@@ -17,14 +22,16 @@ helm repo update
 ## Install the Custom Resource Definitions
 
 ```bash
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.3/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v{INSERT_VERSION_NUMBER_HERE}/cert-manager.crds.yaml
 ```
 
 ## Install using Helm
 
 ```bash
 helm install cert-manager jetstack/cert-manager \
-    --version v1.0.3 \
+    --version VERSION \
+    --create-namespace \
     --namespace cert-manager \
-    -f deploy/cert-manager.yaml
+    --timeout 5m0s \
+    --wait
 ```

--- a/hub23-chart/templates/issuer.yaml
+++ b/hub23-chart/templates/issuer.yaml
@@ -1,29 +1,29 @@
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
-  name: letsencrypt-staging
+  name: hub23-letsencrypt-staging
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     email: hub23registry@turing.ac.uk
     privateKeySecretRef:
-      name: letsencrypt-staging
+      name: hub23-letsencrypt-staging
     solvers:
     - http01:
         ingress:
           class: nginx
 ---
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
-  name: letsencrypt-prod
+  name: hub23-letsencrypt-prod
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
     email: hub23registry@turing.ac.uk
     privateKeySecretRef:
-      name: letsencrypt-prod
+      name: hub23-letsencrypt-prod
     solvers:
     - http01:
         ingress:

--- a/hub23-chart/values.yaml
+++ b/hub23-chart/values.yaml
@@ -28,6 +28,7 @@ binderhub:
       # nginx-ingress controller to be explicitly utilised instead of "gce"
       # This is required to allow nginx-ingress-controller to function. This will override any cloud provided ingress controllers and use the one we choose to deploy, i.e. nginx.
       kubernetes.io/ingress.class: nginx
+      cert-manager.io/issuer: "hub23-letsencrypt-prod"
       https:
         enabled: true
         type: nginx
@@ -48,6 +49,7 @@ binderhub:
       annotations:
         kubernetes.io/tls-acme: "true"
         kubernetes.io/ingress.class: nginx
+        cert-manager.io/issuer: "hub23-letsencrypt-prod"
         https:
           enabled: true
           type: nginx
@@ -85,11 +87,3 @@ nginx-ingress:
   controller:
     config:
       proxy-body-size: 64m
-
-cert-manager:
-  webhook:
-    enabled: false
-  ingressShim:
-    defaultIssuerName: "staging"
-    defaultIssuerKind: "ClusterIssuer"
-    defaultACMEChallengeType: "http01"

--- a/hub23-chart/values.yaml
+++ b/hub23-chart/values.yaml
@@ -25,7 +25,6 @@ binderhub:
       # nginx-ingress controller to be explicitly utilised instead of "gce"
       # This is required to allow nginx-ingress-controller to function. This will override any cloud provided ingress controllers and use the one we choose to deploy, i.e. nginx.
       kubernetes.io/ingress.class: nginx
-      cert-manager.io/issuer: "hub23-letsencrypt-prod"
       https:
         enabled: true
         type: nginx
@@ -46,7 +45,6 @@ binderhub:
       annotations:
         kubernetes.io/tls-acme: "true"
         kubernetes.io/ingress.class: nginx
-        cert-manager.io/issuer: "hub23-letsencrypt-prod"
         https:
           enabled: true
           type: nginx

--- a/hub23-chart/values.yaml
+++ b/hub23-chart/values.yaml
@@ -1,9 +1,6 @@
 rbac:
   enabled: true
 
-letsencrypt:
-  contactEmail: hub23registry@turing.ac.uk
-
 binderhub:
   config:
     BinderHub:


### PR DESCRIPTION
<!-- Thank you for opening a Pull Request! -->

### Summary
<!-- Describe the purpose of the PR.
Is it fixing a bug or adding a feature? -->

Reconfigure cert-manager to use an `Issuer` rather than `ClusterIssuer` so that it can share infrastructure with Turing BinderHub Federation cluster without the certificate emails clashing.

fix https://github.com/jupyterhub/mybinder.org-deploy/issues/1827

### What's changed?
<!-- Describe in more detail what has changed in this section.
We recommend using bullet points. -->

- Updated CD pipeline so that cert-manager is *not* updated. This will be managed by the mybinder.org-deploy repo.
- Changed cert-manage kind to `Issuer`
- Delete extraneous cert-manager config
- Abstract cert-manager annotations out of values.yaml into individual configs so swapping between staging and prod is simplified
- Update cert-manager documentation

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific types of feedback.
We recommend using check boxes. -->

- [ ] Everything looks ok?
