### PR TITLE
👷 Update lint-format CD to use k8s-tools rather than kubeval action

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -63,7 +63,6 @@ jobs:
         uses: stefanprodan/kube-tools@v1.5.0
         with:
           helmv3: 3.5.2
-          kubeval: 0.15.0
           command: |
             echo "#### Setup: Add helm charts"
             helmv3 repo add jupyterhub https://jupyterhub.github.io/helm-chart

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -83,4 +83,4 @@ jobs:
               -f deploy/test-values.yaml \
               --debug | kubeval \
               --kubernetes-version 1.18.1 \
-              --ignore-missing-schema
+              --ignore-missing-schemas

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -77,15 +77,11 @@ jobs:
               -f deploy/prod.yaml \
               -f deploy/test-values.yaml \
               --debug
-            echo "#### Setup: Run helm template"
+            echo "#### TEST 2: Run helm template and pipe to kubeval"
             helmv3 template hub23-chart \
               -f hub23-chart/values.yaml \
               -f deploy/prod.yaml \
               -f deploy/test-values.yaml \
-              --output-dir rendered_templates \
-              --debug
-            echo "#### TEST 2: Run kubeval"
-            kubeval \
-              --directories ./rendered_templates \
+              --debug | kubeval \
               --kubernetes-version 1.18.1 \
               --ignore-missing-schema

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -55,52 +55,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # TODO: Add yamllint
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
+      - name: Run Kubernetes tools
+        uses: stefanprodan/kube-tools@v1.5.0
         with:
-          version: 'v3.5.2'
-
-      - name: Add helm charts
-        run: |
-          helm repo add jupyterhub https://jupyterhub.github.io/helm-chart
-          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-          helm repo update
-
-      - name: Update local chart
-        working-directory: hub23-chart
-        run: |
-          helm dep up
-
-      - name: Run helm lint
-        run: |
-          helm lint hub23-chart \
-            -f hub23-chart/values.yaml \
-            -f deploy/prod.yaml \
-            -f deploy/test-values.yaml \
-            --debug
-
-      - name: Run helm template
-        run: |
-          mkdir rendered_templates
-          helm template hub23-chart \
-            -f hub23-chart/values.yaml \
-            -f deploy/prod.yaml \
-            -f deploy/test-values.yaml \
-            --output-dir rendered_templates \
-            --debug
-
-      # - name: Run yamllint
-      #   uses: bewuethr/yamllint-action@v1
-      #   with:
-      #     config-file: yamllint-config.yaml
-
-      - name: Run kubeval
-        uses: brpaz/gh-action-kubeval@v1.0.1
-        with:
-          files: ./rendered_templates
-          version: 1.18.1
-          ignore_missing_schemas: true
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          helmv3: 3.5.2
+          kubeval: 0.15.0
+          command: |
+            echo "#### Setup: Add helm charts"
+            helmv3 repo add jupyterhub https://jupyterhub.github.io/helm-chart
+            helmv3 repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+            helmv3 repo update
+            echo "#### Setup: Update local chart"
+            cd hub23-chart && helm dep up && cd ..
+            echo "#### TEST 1: Run helm lint"
+            helmv3 lint hub23-chart \
+              -f hub23-chart/values.yaml \
+              -f deploy/prod.yaml \
+              -f deploy/test-values.yaml \
+              --debug
+            echo "#### Setup: Run helm template"
+            helmv3 template hub23-chart \
+              -f hub23-chart/values.yaml \
+              -f deploy/prod.yaml \
+              -f deploy/test-values.yaml \
+              --output-dir rendered_templates \
+              --debug
+            echo "#### TEST 2: Run kubeval"
+            kubeval \
+              --directories ./rendered_templates \
+              --kubernetes-version 1.18.1 \
+              --ignore-missing-schema

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -69,7 +69,7 @@ jobs:
             helmv3 repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
             helmv3 repo update
             echo "#### Setup: Update local chart"
-            cd hub23-chart && helm dep up && cd ..
+            cd hub23-chart && helmv3 dep up && cd ..
             echo "#### TEST 1: Run helm lint"
             helmv3 lint hub23-chart \
               -f hub23-chart/values.yaml \


### PR DESCRIPTION
<!-- Thank you for opening a Pull Request! -->

### Summary
<!-- Describe the purpose of the PR.
Is it fixing a bug or adding a feature? -->

This PR changes the Kubernetes tools used to lint and validate the helm chart in CI. This new action does not require a token so, hopefully, PRs from forks will now pass.