### PR TITLE
Bump helm in CD pipeline to v3.6.3

### DIFF
--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -12,7 +12,7 @@ variables:
 
   helm_chart_name: 'hub23-chart'
   helm_release_name: 'hub23'
-  helm_version: '3.3.4'
+  helm_version: '3.6.3'
 
   kubernetes_cluster_name: 'turing'
   kubernetes_namespace: 'hub23'


### PR DESCRIPTION
This PR bumps the version of helm we use in our Continuous Deployment pipeline. This is needed as our deploys with the most recent charts are failing due to a "dig" command in the z2jh chart that was not available in the old version of helm we were using.