### PR TITLE
Migrate Jupyter Book's TOC to new format

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,4 +1,5 @@
-file: index
+format: jb-article
+root: index
 sections:
 - file: azure-prereqs/index
   sections:


### PR DESCRIPTION
Should fix build in https://github.com/alan-turing-institute/hub23-deploy/pull/415

Build currently failing because it does not have the correct version of Jupyter Book