### PR TITLE
Update cd-pipeline.yml

### DIFF
--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -1,5 +1,9 @@
 trigger:
-  - main
+  # Wait for a previous run to finish before beinning the next triggered run
+  batch: true
+  branches:
+    include:
+    - main
 
 pr: none
 

--- a/.az-pipelines/cd-pipeline.yml
+++ b/.az-pipelines/cd-pipeline.yml
@@ -3,7 +3,7 @@ trigger:
   batch: true
   branches:
     include:
-    - main
+      - main
 
 pr: none
 


### PR DESCRIPTION
Set `trigger.batch = true`. This will make Azure DevOps to wait for a job to finish being starting the next triggered job if multiple jobs are triggered in a short space of time.