### PR TITLE
ensure ingress-nginx config is used

### DIFF
--- a/hub23-chart/values.yaml
+++ b/hub23-chart/values.yaml
@@ -72,7 +72,7 @@ binderhub:
     - name: custom-templates
       mountPath: /etc/binderhub/custom
 
-nginx-ingress:
+ingress-nginx:
   controller:
     config:
       proxy-body-size: 64m


### PR DESCRIPTION
### Summary
<!-- Describe the purpose of the PR.
Is it fixing a bug or adding a feature? -->

nginx-ingress was renamed to ingress-nginx (updated in #311). Config section wasn't updated to match, which meant ingress controller config has been having no effect

### What's changed?
<!-- Describe in more detail what has changed in this section.
We recommend using bullet points. -->

- `ingress-nginx` config key spelling matches chart dependency
- `ingress-nginx` config now has its desired effect, specifically: scoping the ingress controller to its own namespace, and increasing the proxy-body-size (max notebook save size)

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific types of feedback.
We recommend using check boxes. -->

- [ ] ingress-nginx matches name of chart in requirements.yaml
- [ ] Everything looks ok?

After deploying:

```
kubectl get configmap -n hub23 hub23-ingress-nginx-controller -o yaml
```

should show a configmap with something like:

```yaml
data:
  proxy-body-size: 64m
```

